### PR TITLE
add: popover to SmallCardButton

### DIFF
--- a/src/features/smal-cart-button/ui/SmallCartButton/SmallCartButton.tsx
+++ b/src/features/smal-cart-button/ui/SmallCartButton/SmallCartButton.tsx
@@ -1,6 +1,6 @@
 import { Badge, IconButton, Popover, Typography } from '@mui/material';
 import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
-import React from 'react';
+import React, { useCallback } from 'react';
 import Link from 'next/link';
 import { useAppSelector } from 'store/store';
 import { cartModel } from 'entities/cart';
@@ -18,13 +18,16 @@ export const SmallCartButton = () => {
     null,
   );
 
-  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      setAnchorEl(event.currentTarget);
+    },
+    [setAnchorEl],
+  );
 
-  const handleClose = () => {
+  const handleClose = useCallback(() => {
     setAnchorEl(null);
-  };
+  }, [setAnchorEl]);
 
   const open = Boolean(anchorEl);
   const id = open ? 'simple-popover' : undefined;

--- a/src/features/smal-cart-button/ui/SmallCartButton/SmallCartButton.tsx
+++ b/src/features/smal-cart-button/ui/SmallCartButton/SmallCartButton.tsx
@@ -1,22 +1,61 @@
-import { Badge, IconButton } from '@mui/material';
+import { Badge, IconButton, Popover, Typography } from '@mui/material';
 import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
 import React from 'react';
 import Link from 'next/link';
 import { useAppSelector } from 'store/store';
 import { cartModel } from 'entities/cart';
 
+const ProductNameWithErrorList = [
+  'Напиток кокосовый Alpro Barista с соей 1,4% 1 л',
+  'Сухарики Finn Crisp ржаные 200 г',
+];
+
 export const SmallCartButton = () => {
   const cartProductsCount = useAppSelector(
     cartModel.selectors.cartProductsCount,
   );
+  const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(
+    null,
+  );
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
+  const id = open ? 'simple-popover' : undefined;
 
   return (
-    <Link href="/cart" passHref>
-      <IconButton aria-label="cart" component="span">
-        <Badge badgeContent={cartProductsCount} color="secondary">
-          <ShoppingCartIcon color={'inherit'} />
-        </Badge>
-      </IconButton>
-    </Link>
+    <>
+      <Link href="/cart" passHref>
+        <IconButton aria-label="cart" component="span" onMouseOut={handleClick}>
+          <Badge badgeContent={cartProductsCount} color="secondary">
+            <ShoppingCartIcon color={'inherit'} />
+          </Badge>
+        </IconButton>
+      </Link>
+      <Popover
+        id={id}
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'left',
+        }}
+      >
+        <Typography sx={{ p: 2 }}>Внимание:</Typography>
+        {ProductNameWithErrorList.map((name: string) => (
+          <Typography key={name} sx={{ p: 1 }}>
+            {/* eslint-disable-next-line react/no-unescaped-entities */}
+            товара "{name}" доступно только 5 шт
+          </Typography>
+        ))}
+      </Popover>
+    </>
   );
 };


### PR DESCRIPTION
Добавил пока в компонент кнопки корзины, т.к. popover привязывается к расположению этой кнопки. Список товаров для ошибки - захардкодил. Когда добавим в стейт массив с именами товаров (ProductNameWithErrorList), по которым прилетела ошибка с бэкенда, буду брать информацию для отрисовки от туда. Плюс надо продумать, где расположить функционал, который будет скрывать это popover через 1-2 секунды (т.е. очищать поле ProductNameWithErrorList в стейте)